### PR TITLE
Add catalog-info.yaml for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: fastapi-async-sqlmodel
+  annotations:
+    github.com/project-slug: exampleOrg/fastapi-async-sqlmodel
+  tags:
+    - python
+spec:
+  type: service
+  lifecycle: production
+  owner: Cedric-Magnan


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the Cedric-Magnan Backstage App software catalog.

After this pull request is merged, the component will become available.

**To make ownership visible add a [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) file to this repo.**

Feel free to make changes to the file. For more information, read about the [descriptor format of catalog entities](https://backstage.io/docs/features/software-catalog/descriptor-format).